### PR TITLE
RHEL/OL: Serial Console Login Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Workflow for Building Image:
 
 ![image](https://github.com/HewlettPackard/hpegl-metal-os-rhel-iso/assets/90067804/e2a198c4-96f1-4c1c-8fa0-4ac8c730857e)
 
-
 Prerequisites:
 ```
 1. You will need a Web Server with HTTPS support for storage of the HPE Base Metal images.  The Web Server is anything that:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ RHEL/Oracle Linux Bring Your Own Image (BYOI) for HPE Private Cloud Enterprise -
   *   [Adding RHEL service to Bare Metal portal](#adding-rhel-service-to-bare-metal-portal)
   *   [Creating an RHEL Host with RHEL Service](#creating-an-rhel-host-with-rhel-service)
   *   [Triage of image deployment problems](#triage-of-image-deployment-problems)
-  *   [RHEL License](#rhel-license)
   *   [Known Observations/Issues](#known-observations-and-issues)
+  *   [Troubleshooting](#troubleshooting)
   *   [OS License](#os-license)
   *   [Storage Volumes iSCSI and FC](#storage-volumes-iscsi-and-fc)
 
@@ -36,6 +36,7 @@ This GitHub repository contains the script files, template files, and documentat
 Workflow for Building Image:
 
 ![image](https://github.com/HewlettPackard/hpegl-metal-os-rhel-iso/assets/90067804/e2a198c4-96f1-4c1c-8fa0-4ac8c730857e)
+
 
 Prerequisites:
 ```
@@ -281,6 +282,7 @@ Command Line Options                | Description
 ------------------------------------| -----------
 -i \<rhel-iso-filename\>            | local filename of the standard RHEL .ISO file that was already downloaded. Used as input file.
 -v \<rhel-version-number\>          | a x.y RHEL version number.  Example: -v 7.9
+-r \<rhel-rootpw\>                  | clear-text password for the root user. <br> **_NOTE:_**  <br> 1. Later, this clear-text password is encrypted and the Service file (.yml) shows an encrypted password in the kick-start `/KS.cfg` file. <br> 2. This clear-test password will be visible in the build machine's command history. You may identify the command number you want to remove and then use `history -d` followed by the command number.
 -o \<rhel-baremetal-iso\>           | local filename of the Bare Metal modified RHEL .ISO file that will be output by the script.  This file should be uploaded to your web server.
 -p \<image-url-prefix\>             | the beginning of the image URL (on your web server). Example: -p https://10.152.2.125.
 -s \<rhel-baremetal-service-file\>  | local filename of the Bare Metal .YML service file that will be output by the script.  This file should be uploaded to the Bare Metal portal.
@@ -487,6 +489,33 @@ Here are some points to note:
 [Unit]
 ConditionPathExists=!/run/systemd/generator.early/multi-user.target.wants/cloud-init.target
 ```
+
+## Troubleshooting
+
+This section covers common problems and solutions for RHEL/Oracle Linux issues.  
+<1> How to Login using Serial Console  
+Linux kernels can output information including the login prompt to serial ports. Users can open the serial console window to log in to the host.  
+Example for reference:   
+```
+Session established.
+Connecting...
+Connected.
+     <<Press Enter to have Login Prompt>>
+Oracle Linux Server 8.9
+Kernel 5.15.0-200.131.27.el8uek.x86_64 on an x86_64
+                                                                                                                                            
+nb-ol8 login: root
+Password:
+Last login: Mon Aug 12 23:40:51 on ttyS1
+[root@nb-ol8 ~]#
+```
+<2> The serial console can freeze and stop taking input.  
+The user needs to access the host via SSH and run the following steps to resume the console access:  
+A. Verify the following error footprints in the `/var/log/messages` log file: `getty@ttyS1.service: Failed with result 'start-limit-hit'.`  
+B. Restart the service using the command: `systemctl restart  getty@ttyS1.service`  
+C. Verify the `active (running)` status of this systemd service `getty@ttyS1.service`  
+In case the user can't log in via SSH, please do a graceful host reboot.  
+Note: The user may refer to a relevant issue on RedHat Customer Portal: https://access.redhat.com/solutions/7004165 
 
 ## OS License
 

--- a/glm-build-image-and-service.sh
+++ b/glm-build-image-and-service.sh
@@ -69,7 +69,7 @@ do
         # required parameters
         i) RHEL_ISO_FILENAME=$OPTARG ;;
         v) OS_VER=$OPTARG ;;
-        r) RHEL_ROOTPW=$OPTARG ;;
+        r) RHEL_ROOTPW=`openssl passwd -6 -salt xyz $OPTARG` ;;
         o) GLM_CUSTOM_RHEL_ISO=$OPTARG ;;
         p) IMAGE_URL_PREFIX=$OPTARG ;;
         s) GLM_YML_SERVICE_FILE=$OPTARG ;;
@@ -116,8 +116,8 @@ fi
 GLM_YML_SERVICE_TEMPLATE=$(mktemp /tmp/glm-service.cfg.XXXXXXXXX)
 sed -e "s/%OS_VERSION%/$OS_VER/g" glm-service.yml.template > $GLM_YML_SERVICE_TEMPLATE
 
-# set the root password in the KS configuration file
-sed -i "s/%ROOTPW%/$RHEL_ROOTPW/g" glm-kickstart.cfg.template
+# set the user provided root password in the KS configuration file
+sed -i "s'%ROOTPW%'$RHEL_ROOTPW'g" glm-kickstart.cfg.template
 
 # extract the Service Flavor from the GLM_CUSTOM_RHEL_ISO
 # such that GLM_CUSTOM_RHEL_ISO contains the word RHEL|Oracle|Rocky
@@ -149,7 +149,7 @@ echo $GEN_SERVICE
 $GEN_SERVICE
 
 # unset the root password in the KS configuration file
-sed -i '/rootpw/c\rootpw %ROOTPW%' glm-kickstart.cfg.template
+sed -i '/rootpw/c\rootpw %ROOTPW% --iscrypted' glm-kickstart.cfg.template
 
 # print out instructions for using this image & service
 cat << EOF

--- a/glm-cloud-init.template
+++ b/glm-cloud-init.template
@@ -18,6 +18,10 @@ manage_etc_hosts: true
 # ----------------------------------------------------
 users:
   - name: root
+    # Reference: https://cloudinit.readthedocs.io/en/latest/reference/examples.html
+    #   lock_passwd: Defaults to true. Lock the password to disable password login.
+    #   Set it to false to unlock the password (for root login at the serial console).
+    lock_passwd: false
 {{- if .SSHKeys }}
     ssh_authorized_keys:
   {{- range $key := .SSHKeys}}

--- a/glm-kickstart.cfg.template
+++ b/glm-kickstart.cfg.template
@@ -151,8 +151,9 @@ network --bootproto=dhcp --device={{.HWAddr}} --ipv6=auto --activate
 # Include the /ks-storage.cfg file that we generated in the %pre section
 %include "/ks-storage.cfg"
 
-# Required: Sets the root password for the system.
-rootpw %ROOTPW%
+# Required field:
+# Sets an encrypted root password for the system.
+rootpw %ROOTPW% --iscrypted
 
 # node_exporter user
 user --name=node_exporter --shell=/sbin/nologin


### PR DESCRIPTION
Pushing the latest changes from bmaas-byoi-rhel-build:
-
1. Fix for DE23030 (about Serial Console root Login)
2. The root user password is encrypted
3. Documentation updated (section "Troubleshooting" is added)
