### PR TITLE
BYOI RHEL/OL/Rocky | Enhance the design to fix intermittent issues plus documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- (C) Copyright 2024 Hewlett Packard Enterprise Development LP -->
 
-RHEL/Oracle Linux Bring Your Own Image (BYOI) for HPE Private Cloud Enterprise - Bare Metal
+RHEL/Oracle/Rocky Linux Bring Your Own Image (BYOI) for HPE Private Cloud Enterprise - Bare Metal
 =============================
 
 * [Overview](#overview)
@@ -16,7 +16,7 @@ RHEL/Oracle Linux Bring Your Own Image (BYOI) for HPE Private Cloud Enterprise -
   *   [Adding RHEL service to Bare Metal portal](#adding-rhel-service-to-bare-metal-portal)
   *   [Creating an RHEL Host with RHEL Service](#creating-an-rhel-host-with-rhel-service)
   *   [Triage of image deployment problems](#triage-of-image-deployment-problems)
-  *   [Known Observations/Issues](#known-observations-and-issues)
+  *   [Known Observations and Limitations](#known-observations-and-limitations)
   *   [Troubleshooting](#troubleshooting)
   *   [OS License](#os-license)
   *   [Storage Volumes iSCSI and FC](#storage-volumes-iscsi-and-fc)
@@ -37,14 +37,39 @@ Workflow for Building Image:
 
 ![image](https://github.com/HewlettPackard/hpegl-metal-os-rhel-iso/assets/90067804/e2a198c4-96f1-4c1c-8fa0-4ac8c730857e)
 
-Prerequisites:
+
+**Prerequisites:**
 ```
-1. You will need a Web Server with HTTPS support for storage of the HPE Base Metal images.  The Web Server is anything that:
-   A. You have the ability to upload large .ISO image to and
-   B. The Web Server must be on a network that will be reachable from the HPE On-Premises Controller.  When an OS service/image is used to create an HPE Bare Metal Host the OS images will be downloaded via the secure URL in the service file.
-   NOTE: For this manual build example, a local Web Server "https://<web-server-address>" is used for OS image storage.  For this example, we are assuming that the HPE Bare Metal OS images will be kept in: https://<web-server-address>/images/<.iso>.
-2. Linux machine for building OS image
-   A. Ubuntu 20.04.6 LTS
+1. You will need a Web Server with HTTPS support for storage of the HPE Base Metal images.
+2. The Web Server is anything that:
+    A. you have the ability to upload large OS image (.iso) to, and
+    B. is on a network that will be reachable from the HPE On-Premises Controller.
+       When an OS image service (.yml) is used to create an HPE Bare Metal Host, the HPE Bare Metal
+       OS image (.iso) will be downloaded via the `secure_url` mentioned in the service file (.yml).
+3. IMPORTANT:
+   The test `glm-test-service-image.sh` script is to verify the HPE Bare Metal OS image (.iso).
+   To run this test, edit the file `./glm-build-image-and-service.sh` to set the required
+   Web Server-related parameters, listed below:
+      +----------------------------------------------------------------------------
+      | +--------------------------------------------------------------------------
+      | | File `./glm-build-image-and-service.sh`
+      | |   <1> WEB_SERVER_IP: IP address of web server to transfer ISO to (via SSH)
+      | |       Example: WEB_SERVER_IP="10.152.3.96"
+      | |   <2> REMOTE_PATH:   Path on web server to copy files to
+      | |       Example: REMOTE_PATH="/var/www/images/"
+      | |   <3> SSH_USER:      Username for SSH transfer
+      | |       Example: SSH_USER_NAME="root"
+      | | Note: Add your Linux test machine's SSH key to the Web Server
+      | +--------------------------------------------------------------------------
+      +----------------------------------------------------------------------------
+   In this document, for the manual build example:
+   A. a local Web Server "https://10.152.3.96" is used for the storage of OS images (.iso).
+   B. we are assuming that the HPE Bare Metal OS images will be kept in: https://10.152.3.96/images/<.iso>
+4. Linux machine for building OS image:
+   A. Image building has been successfully tested with the following list of Ubuntu OS and its LTS versions:
+      Ubuntu 20.04.6 LTS (focal)
+      Ubuntu 22.04.5 LTS (jammy)
+      Ubuntu 24.04.1 LTS (noble)
    B. Install supporting tools (git, xorriso, and isomd5sum)
 ```
 
@@ -60,17 +85,28 @@ Step 2. Download the RHEL .ISO image to your local build environment via what ev
 
 For example, we will assume that you have downloaded RHEL-9.0.0-20220810.0-x86_64-HPE.iso into the local directory.
 
-Step 3. Run the script `glm-build-image-and-service.sh` to generate an output Bare Metal image .ISO as well as Bare Metal Service .yml:
+Step 3. Run the script [glm-build-image-and-service.sh](glm-build-image-and-service.sh) to generate an output Bare Metal image .ISO as well as Bare Metal Service .yml:
 
-Example:
+Example: Run the build including artifact verification
 ```
 ./glm-build-image-and-service.sh \
   -v 9.0 \
-  -p https://10.152.2.125 \
+  -p https://10.152.3.96 \
   -r qPassw0rd \
   -i RHEL-9.0.0-20220810.0-x86_64-HPE.iso \
   -o RHEL-9.0-BareMetal.iso \
   -s RHEL-9.0-BareMetal.yml
+```
+Example: Run the build excluding artifact verification
+```
+./glm-build-image-and-service.sh \
+  -v 9.0 \
+  -p https://10.152.3.96 \
+  -r qPassw0rd \
+  -i RHEL-9.0.0-20220810.0-x86_64-HPE.iso \
+  -o RHEL-9.0-BareMetal.iso \
+  -s RHEL-9.0-BareMetal.yml \
+  -x true
 ```
 
 Example test result for reference:
@@ -84,69 +120,28 @@ Example test result for reference:
 | |
 | | To use this new Bare Metal RHEL service/image in the HPE Bare Metal, take the following steps:
 | | (1) Copy the new .ISO file (RHEL-9.0-BareMetal.iso)
-| |     to your web server (https://10.152.2.125)
+| |     to your web server (https://10.152.3.96)
 | |     such that the file can be downloaded from the following URL:
-| |     https://10.152.2.125/images/RHEL-9.0-BareMetal.iso
-| | (2) Use the script "glm-test-service-image.sh" to test that the HPE Bare Metal service
-| |     .yml file points to the expected OS image on the web server with the expected OS image
-| |     size and signature.
-| | (3) Add the Bare Metal Service file (RHEL-9.0-BareMetal.yml) to the HPE Bare Metal Portal
+| |     https://10.152.3.96/images/RHEL-9.0-BareMetal.iso
+| | (2) Add the Bare Metal Service file (RHEL-9.0-BareMetal.yml) to the HPE Bare Metal Portal
 | |     (https://client.greenlake.hpe-gl-intg.com/). To add the HPE Bare Metal Service file,
 | |     sign in to the HPE Bare Metal Portal and select the Tenant by clicking "Go to tenant".
 | |     Select the Dashboard tile "Metal Consumption" and click on the Tab "OS/application images".
 | |     Click on the button "Add OS/application image" to Upload the OS/application YML file.
-| | (4) Create a Bare Metal host using this OS image service.
+| | (3) Create a Bare Metal host using this OS image service.
 | +----------------------------------------------------------------------------------------
 +------------------------------------------------------------------------------------------
 ```
 
 Step 4. Copy the output Bare Metal image .ISO to the Web Server.
 
-Step 5. Run the script `glm-test-service-image.sh`, which will verify that the OS image referred to in a corresponding Bare Metal OS service .yml is correct:
-> [!NOTE]  
-> This script will verify that it can download the OS image and check its length (in bytes) and signature.
-> The script simulates what HPE On-Premises Controller will do when it tries to download and verify an OS image.
-> If this script fails then the Bare Metal OS service .yml file is most likely broken and will not work if loaded into Bare Metal.
-
-Example:
-```
-./glm-test-service-image.sh RHEL-9.0-BareMetal.yml
-```
-
-Test result example for reference:
-
-```
-$ ./glm-test-service-image.sh RHEL-9.0-BareMetal.yml
-OS image file to be tested:
-  Secure URL: https://<web-server-address>/images/RHEL-9.0-BareMetal.iso
-  Display URL: RHEL-9.0.0-20220810.0-x86_64-HPE.iso
-  Image size: 8484028416
-  Image signature: ca6235cfb2734bdea71fc3794a32f8b3c71bbc019d15e274e271de668ccc86f1
-  Signature algorithm: sha256sum
-
-wget -O /tmp/os-image-M9V0GR.img https://10.152.2.125/images/RHEL-9.0-BareMetal.iso
---2024-03-28 17:26:47--  https://10.152.2.125/images/RHEL-9.0-BareMetal.iso
-Connecting to 10.152.2.125:80... connected.
-HTTP request sent, awaiting response... 200 OK
-Length: 8484028416 (7.9G) [application/x-iso9660-image]
-Saving to: ‘/tmp/os-image-M9V0GR.img’
-
-/tmp/os-image-M9V0GR.img                            100%[=================================================================================================================>]   7.90G  85.6MB/s    in 89s
-
-2024-03-28 17:28:16 (90.8 MB/s) - ‘/tmp/os-image-M9V0GR.img’ saved [8484028416/8484028416]
-
-Image Size has been verified ( 8484028416 bytes )
-Image Signature has been verified ( ca6235cfb2734bdea71fc3794a32f8b3c71bbc019d15e274e271de668ccc86f1 )
-The OS image size and signature have been verified
-```
-
-Step 6. Add the Bare Metal service .yml file to the appropriate Bare Metal portal.
+Step 5. Add the Bare Metal service .yml file to the appropriate Bare Metal portal.
 
 To add the Bare Metal service .yml file, sign in to the HPE Bare Metal Portal and select the Tenant by clicking "Go to tenant".
 Select the Dashboard tile "Metal Consumption" and click on the "OS/application images" tab.
 Click on the button "Add OS/application image" to upload this service .yml file.
 
-Step 7. Create a new Bare Metal host using this OS image service.
+Step 6. Create a new Bare Metal host using this OS image service.
 
 To create a new Bare Metal host, sign in to the HPE Bare Metal Portal and select the Tenant by clicking "Go to tenant".
 Select the Dashboard tile "Metal Consumption" and click on the tab "Compute groups". Further, create a host using the following steps:
@@ -158,8 +153,11 @@ b. Create a Compute Instance by clicking the "Create compute instance" button an
 
 These are the high-level steps required to generate the Bare Metal RHEL service:
 * Set up a Linux system with 20-40GB of free file system space for the build
-* Set up a local file transfer/storage tool (E.g. Local Web Server with HTTPS support) that Bare Metal can reach over the network.
-  * See [Hosting](Hosting.md) file for additional requirements on the web server.
+* Set up a local file transfer/storage tool (E.g. **Local Web Server with HTTPS support**) that Bare Metal can reach over the network.
+  * For **unsecured Web Server access**, please refer to the [Hosting](Hosting.md) for additional requirements, listed below:
+    *  A. **HTTPS** with certificates signed by **publicly trusted Certificate authority**, and
+    *  B. **Skip** the host’s **SSL certificate verification**.
+  * For **Web Server running behind the Firewall**, the Web Server IP address and Port has to be whitelisted in the **rules** and **Proxy**.
 * Install Git Version Control (git) and other ISO tools (xorriso and isomd5sum)
 * Downloading recipe repo from GitHub
 * Download a RHEL .ISO file
@@ -213,10 +211,14 @@ This RHEL recipe has been successfully tested with the following list of RHEL di
 * RHEL 9.0
 * RHEL 9.1
 * RHEL 9.2
+* RHEL 9.4
+* RHEL 9.5
 * Oracle Linux 8.6
 * Oracle Linux 8.9
 * Oracle Linux 9.3
+* Oracle Linux 9.4
 * Rocky Linux 8.8
+* Rocky Linux 9.0
 
 > [!NOTE]  
 > This recipe should work on other RHEL or RHEL-based distros that support the same kickstart and .ISO construction as the recent version of RHEL.  
@@ -283,8 +285,9 @@ Command Line Options                | Description
 -v \<rhel-version-number\>          | a x.y RHEL version number.  Example: -v 7.9
 -r \<rhel-rootpw\>                  | clear-text password for the root user. <br> **_NOTE:_**  <br> 1. Later, this clear-text password is encrypted and the Service file (.yml) shows an encrypted password in the kick-start `/KS.cfg` file. <br> 2. This clear-test password will be visible in the build machine's command history. You may identify the command number you want to remove and then use `history -d` followed by the command number.
 -o \<rhel-baremetal-iso\>           | local filename of the Bare Metal modified RHEL .ISO file that will be output by the script.  This file should be uploaded to your web server.
--p \<image-url-prefix\>             | the beginning of the image URL (on your web server). Example: -p https://10.152.2.125.
+-p \<image-url-prefix\>             | the beginning of the image URL (on your web server). Example: -p https://10.152.3.96.
 -s \<rhel-baremetal-service-file\>  | local filename of the Bare Metal .YML service file that will be output by the script.  This file should be uploaded to the Bare Metal portal.
+-x \<skip-test>                     | [optional] skip the test with "-x true". <br> **_NOTE:_**  <br> By default, this script will run the test [glm-test-service-image.sh](glm-test-service-image.sh) script to verify that the upload was correct, and the size and checksum of the ISO match what is defined in the YML.
 
 > [!NOTE]  
 > The users of this script are expected to copy the \<rhel-baremetal-iso\> .ISO file to your web server
@@ -373,7 +376,7 @@ Example:
     -c linux \
     -f RHEL \
     -v 9.0-20240328-BYOI \
-    -u https://10.152.2.125/images/RHEL-9.0-BareMetal.iso \
+    -u https://10.152.3.96/images/RHEL-9.0-BareMetal.iso \
     -d RHEL-9.0.0-20220810.0-x86_64-HPE.iso \
     -i RHEL-9.0-BareMetal.iso \
     -t glm-kickstart.cfg.template \
@@ -382,7 +385,7 @@ Example:
 
 ### glm-test-service-image.sh - Verify the Bare Metal OS image
 
-This script `glm-test-service-image.sh` will verify that the OS image referred to in a corresponding Bare Metal OS service. yml is correct.
+This script [glm-test-service-image.sh](glm-test-service-image.sh) will verify that the OS image referred to in a corresponding Bare Metal OS service. yml is correct.
 
 Usage:
 ```
@@ -417,6 +420,7 @@ glm-service-build.sh           | This script generates a Bare Metal OS service .
 glm-test-service-image.sh      | This script will verify that the OS image referred to in a corresponding Bare Metal OS service .yml is correct.
 glm-kickstart.cfg.template     | The core RHEL kickstart file (templated with install-env-v1)
 glm-service.yml.template       | This is the Bare Metal .YML service file template.
+Hosting.md                     | This file is for additional requirements on the web server.
 
 Feel free to modify these files to suit your specific needs.
 General changes that you want to contribute back via a pull request are much appreciated.
@@ -444,18 +448,15 @@ For example:
 | |
 | | To use this new Bare Metal RHEL service/image in the HPE Bare Metal, take the following steps:
 | | (1) Copy the new .ISO file (RHEL-9.0-BareMetal.iso)
-| |     to your web server (https://10.152.2.125)
+| |     to your web server (https://10.152.3.96)
 | |     such that the file can be downloaded from the following URL:
-| |     https://10.152.2.125/images/RHEL-9.0-BareMetal.iso
-| | (2) Use the script "glm-test-service-image.sh" to test that the HPE Bare Metal service
-| |     .yml file points the expected OS image on the web server with the expected OS image
-| |     size and signature.
-| | (3) Add the Bare Metal Service file (RHEL-9.0-BareMetal.yml) to the HPE Bare Metal Portal
+| |     https://10.152.3.96/images/RHEL-9.0-BareMetal.iso
+| | (2) Add the Bare Metal Service file (RHEL-9.0-BareMetal.yml) to the HPE Bare Metal Portal
 | |     (https://client.greenlake.hpe-gl-intg.com/). To add the HPE Bare Metal Service file,
 | |     sign in to the HPE Bare Metal Portal and select the Tenant by clicking "Go to tenant".
 | |     Select the Dashboard tile "Metal Consumption" and click on the Tab "OS/application images".
 | |     Click on the button "Add OS/application image" to Upload the OS/application YML file.
-| | (4) Create a Bare Metal host using this OS image service.
+| | (3) Create a Bare Metal host using this OS image service.
 | +----------------------------------------------------------------------------------------
 +------------------------------------------------------------------------------------------
 ```
@@ -474,20 +475,11 @@ Here are some points to note:
   * HPE GreenLake Metal tools do not monitor the serial port(s) at this time so if an error is generated by the RHEL installer, the Bare Metal tools will not know about it.
   * Sometimes for more difficult OS deployment problems you might want to gain access to the servers iLO so that you can monitor it that way. See your Bare Metal administrator.
 
-## Known Observations and Issues
+## Known Observations and Limitations
 
-<1> For Oracle Linux  
-**About Issue:** Services (sshd/cloud-init) found inactive. This results into an error `sshd: no hostkeys available -- exiting` and User can not SSH to the host.  
-**About Fix:** Reboot the Host once. Reboot will bring up the host with active sshd services and required host keys.  
-**Reference file:** '/etc/systemd/system/sshd-keygen@.service.d/disable-sshd-keygen-if-cloud-init-active.conf'  
-```
-# In some cloud-init enabled images the sshd-keygen template service may race with cloud-init
-# during boot causing issues with host key generation.  This drop-in config adds a condition
-# to sshd-keygen@.service if it exists and prevents the sshd-keygen units from running
-# *if* cloud-init is going to run.
-[Unit]
-ConditionPathExists=!/run/systemd/generator.early/multi-user.target.wants/cloud-init.target
-```
+<1> Host readiness for the user to log in  
+After the host is created successfully, the Portal UI shows progress 100%.  
+However, the host os is still booting up in the background, resulting in user login (serial console login and SSH login) being delayed by 2 to 3 minutes.
 
 ## Troubleshooting
 

--- a/glm-build-image-and-service.sh
+++ b/glm-build-image-and-service.sh
@@ -2,11 +2,11 @@
 # (C) Copyright 2018-2022, 2024 Hewlett Packard Enterprise Development LP
 
 # This is the top-level build script that will take an RHEL install ISO and
-# generate a RHEL service.yml file that can be imported as a Host OS into
+# generate an RHEL service.yml file that can be imported as a Host OS into
 # a Bare Metal portal.
 
 # glm-build-image-and-service.sh does the following steps:
-# * process command line arguements.
+# * process command line arguments.
 # * Customize the RHEL .ISO so that it works for Bare Metal.  Run: glm-image-build.sh.
 # * Generate Bare Metal service file that is specific to $OS_VER. Run: glm-service-build.sh.
 
@@ -36,25 +36,50 @@
 #                            | will be output by the script.  This file should
 #                            | be uploaded to the Bare Metal portal.
 # -------------------------- | -----------
+# -x <skip-test>             | [optional] Skip the test with "-x true"
+#                            | By default this script will run the test "glm-test-service-image.sh"
+#                            | script to verify that the upload was correct, and the size and checksum
+#                            | of the ISO matches what is defined in the YML.
+# -------------------------- | -----------
 
-# NOTE: The user's of this script are expected to copy the
-# <glm-custom-rhel-iso> .ISO file to your web server such
-# that the file is available at this constructed URL:
-# <image-url-prefix>/<glm-custom-rhel-iso>
+# NOTE: Make sure to upload the <glm-custom-rhel-iso> .ISO file to your web server to make it accessible
+# at this constructed URL: # <image-url-prefix>/<glm-custom-rhel-iso>
 
-# If the image URL can't not be constructed with this
-# simple mechanism then you probably need to customize
-# this script for a more complex URL costruction.
+# If the image URL can not be constructed with this simple mechanism, then you probably need to customize
+# this script for a more complex URL construction.
 
-# This script calls glm-image-build.sh, which needs the
-# following packages to be installed:
-#
-# on Debian/Ubuntu:
-#  sudo apt install xorriso isomd5sum
+# This script calls `glm-image-build.sh`, which needs the following packages to be installed on Debian/Ubuntu:
+# Command: `sudo apt install xorriso isomd5sum`
+
+# To run the test script: glm-test-service-image.sh
+#   By default this script will run the test script "glm-test-service-image.sh"
+#   to verify that the upload was correct, and the size and checksum of the
+#   ISO matches what is defined in the YML.
+#   Example:
+#     ./glm-build-image-and-service.sh           \
+#     -i images/OracleLinux-R8-U9-x86_64-dvd.iso \
+#     -v 8.9                                     \
+#     -r PASSWORD                                \
+#     -p https://10.152.3.96                     \
+#     -o images/OracleLinux-R8-U9-x86_64-GLM.iso \
+#     -s images/OracleLinux-R8-U9-x86_64-GLM.yml
 
 set -euo pipefail
 
-# required parameters
+# ==================================================================================
+# Prerequisites:
+# ==================================================================================
+# Required parameters for Image Web Server and test script "glm-test-service-image.sh"
+#   WEB_SERVER_IP: IP address of web server to transfer ISO to (via SSH)
+#   REMOTE_PATH:   Path on web server to copy files to
+#   SSH_USER:      Username for SSH transfer
+#   Note: Add your Linux test machine's SSH key to the Web Server
+WEB_SERVER_IP="10.152.3.96"
+REMOTE_PATH="/var/www/images/"
+SSH_USER_NAME="root"
+# ==================================================================================
+
+# other required parameters
 RHEL_ISO_FILENAME=""
 GLM_CUSTOM_RHEL_ISO=""
 OS_VER=""
@@ -62,8 +87,9 @@ RHEL_ROOTPW=""
 IMAGE_URL_PREFIX=""
 GLM_YML_SERVICE_FILE=""
 GLM_YML_SERVICE_TEMPLATE=""
+SKIP_TEST=""
 
-while getopts "i:v:r:o:p:s:" opt
+while getopts "i:v:r:o:p:s:x:" opt
 do
     case $opt in
         # required parameters
@@ -73,6 +99,8 @@ do
         o) GLM_CUSTOM_RHEL_ISO=$OPTARG ;;
         p) IMAGE_URL_PREFIX=$OPTARG ;;
         s) GLM_YML_SERVICE_FILE=$OPTARG ;;
+        x) SKIP_TEST=$OPTARG ;;
+        *) echo "ERROR invalid parameter."; exit 1 ;;
      esac
 done
 
@@ -89,18 +117,41 @@ if [ -z "$RHEL_ISO_FILENAME" -o \
 fi
 
 if [[ ! -f $RHEL_ISO_FILENAME ]]; then
-  echo "ERROR missing ISO image file $RHEL_ISO_FILENAME"
-  exit 1
+   echo "ERROR missing ISO image file $RHEL_ISO_FILENAME"
+   exit 1
 fi
 
 # The clean function cleans up any lingering files
 # that might be present when the script exits.
 clean() {
-  if [ ! -z "$GLM_YML_SERVICE_TEMPLATE" ]; then
-    rm -f $GLM_YML_SERVICE_TEMPLATE
+   if [ ! -z "$GLM_YML_SERVICE_TEMPLATE" ]; then
+      rm -f $GLM_YML_SERVICE_TEMPLATE
   fi
 }
 
+# By default this script will run the test "glm-test-service-image.sh" script
+# to verify that the upload was correct, and the size and checksum of the
+# ISO matches what is defined in the YML.
+# Note: Set the Web Server related parameters at the top
+#   User may verify SCP transfer using following commands:
+#     $ echo bye | sftp -b - ${SSH_USER_NAME}@${WEB_SERVER_IP}
+#     $ rsync -av --dry-run ${SOURCE} ${DESTINATION}
+run_test() {
+if [ "${SKIP_TEST}" != "true" ]; then
+  # Run the test by default
+   echo -e "\nCopying .ISO file to the web server..."
+   SOURCE="${GLM_CUSTOM_RHEL_ISO}"
+   DESTINATION="${SSH_USER_NAME}@${WEB_SERVER_IP}:${REMOTE_PATH}"
+   echo "scp ${SOURCE} ${DESTINATION}"
+   scp ${SOURCE} ${DESTINATION}
+   if [ $? -ne 0 ]; then echo "ERROR scp failed to copy image"; exit 1; fi
+   echo -e "\nRunning the test "glm-test-service-image.sh"..."
+   echo "./glm-test-service-image.sh ${GLM_YML_SERVICE_FILE}"
+   ./glm-test-service-image.sh ${GLM_YML_SERVICE_FILE}
+fi
+}
+
+# Set a trap to call the clean function on exit
 trap clean EXIT
 
 # if the Bare Metal customized RHEL .ISO has not already been generated.
@@ -151,7 +202,16 @@ $GEN_SERVICE
 # unset the root password in the KS configuration file
 sed -i '/rootpw/c\rootpw %ROOTPW% --iscrypted' glm-kickstart.cfg.template
 
+# By default run the test script "glm-test-service-image.sh" to verify ISO image
+run_test
+
 # print out instructions for using this image & service
+NOTE="| |     
+| |     IMPORTANT: Use the test (glm-test-service-image.sh) script to verify that
+| |                the ISO upload was correct, and the size and checksum of the ISO
+| |                match what is defined in the YML.
+| |"
+
 cat << EOF
 +------------------------------------------------------------------------------------------
 | +----------------------------------------------------------------------------------------
@@ -162,18 +222,16 @@ cat << EOF
 | |
 | | To use this new Bare Metal $SVC_FLAVOR service/image in Bare Metal, take the following steps:
 | | (1) Copy the new .ISO file ($GLM_CUSTOM_RHEL_ISO)
-| |     to your web server ($IMAGE_URL_PREFIX)
-| |     such that the file can be downloaded from the following URL:
-| |     $IMAGE_URL_PREFIX/$GLM_CUSTOM_RHEL_ISO
-| | (2) Use the script "glm-test-service-image.sh" to test that the HPE Bare Metal service
-| |     .yml file points to the expected OS image on the web server with the expected OS image
-| |     size and signature.
-| | (3) Add the Bare Metal Service file ($GLM_YML_SERVICE_FILE) to the HPE Bare Metal Portal
+| |     to your web server ($IMAGE_URL_PREFIX) such that the file can be downloaded
+| |     from the following URL: $IMAGE_URL_PREFIX/$GLM_CUSTOM_RHEL_ISO
+`if [ "${SKIP_TEST}" == "true" ]; then echo "${NOTE}"; echo ; else echo "| |"; fi`
+| | (2) Add the Bare Metal Service file ($GLM_YML_SERVICE_FILE) to the HPE Bare Metal Portal
 | |     (https://client.greenlake.hpe-gl-intg.com/). To add the HPE Metal Service file,
 | |     sign in to the Bare Metal Portal and select the Tenant by clicking "Go to tenant".
 | |     Select the Dashboard tile "Metal Consumption" and click on the Tab "OS/application images".
 | |     Click on the button "Add OS/application image" to Upload the OS/application YML file.
-| | (4) Create a Bare Metal host using this OS image service.
+| |
+| | (3) Create a Bare Metal host using this OS image service.
 | +----------------------------------------------------------------------------------------
 +------------------------------------------------------------------------------------------
 EOF

--- a/glm-cloud-init.template
+++ b/glm-cloud-init.template
@@ -60,12 +60,17 @@ users:
   {{- end}}
 {{- end}}
 
+# cloud-init module "write_file" is to create a new file or 
+#   overwrite an existing file during initialization.
+# ----------------------------------------------------
 write_files:
+    # System Configuration file for node exporter
   - path: /etc/sysconfig/node_exporter
     owner: node_exporter
     permissions: '0644'
     content: |
         ARGS="--web.listen-address=\":45678\""
+    # Systemd unit files created by systemctl enable
   - path: /etc/systemd/system/node_exporter.service
     owner: root
     permissions: '0644'
@@ -79,14 +84,16 @@ write_files:
         [Install]
         WantedBy=multi-user.target
 {{- /* verify the rest of write_files: is needed */}}
-  {{- if  .InitiatorName}}
+{{- if  .InitiatorName}}
+    # Set initiator name
   - path: /etc/iscsi/initiatorname.iscsi
     owner: root
     permissions: '0644'
     content: |
       InitiatorName={{.InitiatorName}}
-  {{- end}}
-  {{- if  .CHAPSecret}}
+{{- end}}
+{{- if  .CHAPSecret}}
+    # Set iSCSI target with CHAP authorization
   - path: /etc/iscsi/iscsid.conf
     owner: root
     permissions: '0644'
@@ -95,8 +102,9 @@ write_files:
       node.session.auth.username = {{.CHAPUser}}
       node.session.auth.password = {{.CHAPSecret}}
       node.startup = automatic
-  {{- end}}
-  {{- if $proxy }}
+{{- end}}
+{{- if $proxy }}
+    # Set proxy settings
   - path: /etc/environment
     owner: root
     permissions: '0644'
@@ -107,11 +115,64 @@ write_files:
         HTTP_PROXY={{$proxy}}
         HTTPS_PROXY={{$proxy}}
         NO_PROXY={{$no_proxy}}
-  {{- end}}
+{{- end}}
+    # Writing script for node exporter service; executes under runcmd
+  - path: /var/lib/cloud/instance/scripts/glm-node-exporter.sh
+    owner: root
+    permissions: '0775'
+    content: |
+      #!/bin/bash
+      curl_cmd="curl --silent --location"
+    {{- if $proxy }}
+      curl_cmd+=" --proxy {{$proxy}}"
+    {{- end }}
+      echo "$(date '+%Y%m%d-%H:%M:%S') curl_cmd=${curl_cmd}" > /var/log/glm-node-exporter.log
+      for try in {1..3} ; do
+        download_url=$(${curl_cmd} \
+        https://api.github.com/repos/prometheus/node_exporter/releases/latest | grep "browser_download_url.*linux-amd64.tar.gz" | cut -d ':' -f2,3 | tr -d \")
+        echo "$(date '+%Y%m%d-%H:%M:%S') download_url=${download_url}" >> /var/log/glm-node-exporter.log
+        ${curl_cmd} ${download_url} > node_exporter.tar.gz
+        echo "$(date '+%Y%m%d-%H:%M:%S') PNE Source- $(ls -lrt node_exporter.tar.gz)" >> /var/log/glm-node-exporter.log
+        tar zxf node_exporter.tar.gz
+        if [ -f node_exporter-*/node_exporter ]; then
+          mv node_exporter-*/node_exporter /usr/bin
+          rm -rf node_exporter*
+          chown node_exporter:node_exporter /usr/bin/node_exporter
+          chcon -t bin_t /usr/bin/node_exporter
+          systemctl daemon-reload
+          systemctl enable node_exporter
+          systemctl start node_exporterbreak
+          break
+        fi
+        echo "$(date '+%Y%m%d-%H:%M:%S') ERROR failed to download the node exporter source file, attempt $try of 3" >> /var/log/glm-node-exporter.log
+      done
+    # Writing script for iscsid service; executes under runcmd
+  - path: /var/lib/cloud/instance/scripts/glm-iscsid.sh
+    owner: root
+    permissions: '0775'
+    content: |
+      #!/bin/bash
+      systemctl enable iscsid
+      systemctl start iscsid
+      echo $(date '+%Y%m%d-%H:%M:%S') $(systemctl status iscsid | grep -i pid) > /var/log/glm-iscsid.log
+    {{- if .VolumeAttachments}}
+      # iSCSI Volume attachments
+      # ----------------------------------------------------
+      # This requires host to create with a Volume attached and will
+      # setup multipathd to create dm device for it. Once host is up,
+      # Metal can add additional volume attachments and user will need
+      # to do "iscsiadm -m session --rescan" and new dm device will be created.
+    {{- range $da := .ISCSIDiscoveryAddressesV3}}
+      iscsiadm --mode discovery -t sendtargets  -p "{{$da }}"
+    {{- end}}
+    {{- if .ISCSIDiscoveryAddressesV3}}
+      iscsiadm --mode node --login
+    {{- end}}
+    {{- end}}
 
-{{ if .Connections}}
 # network connections
 # ----------------------------------------------------
+{{ if .Connections}}
 network:
   version: 1
   config:
@@ -195,10 +256,9 @@ network:
   {{- end}}  {{/* range .Connections  */}}
 {{- end}}    {{/* end if .Connections */}}
 
-{{- if $ntp}}
-
 # NTP server information
 # ----------------------------------------------------
+{{- if $ntp}}
 ntp:
   enabled: true
   servers:
@@ -207,42 +267,24 @@ ntp:
   {{- end}}
 {{- end}}
 
+# cloud-init module "runcmd" is a configuration option that allows users to run commands during boot.
+#   Example: installing software or configuring services.
+#   default: none
+#   runcmd only runs during the first boot
+#   Note: Source path of all script files: "/var/lib/cloud/instance/scripts/<script_files>"
+# ----------------------------------------------------
 runcmd:
-  - |
-    curl_cmd="curl --silent --location \
-{{- if $proxy }}
-    --proxy {{$proxy}} \
-{{- end }}
-    "
-    download_url=`${curl_cmd} \
-    https://api.github.com/repos/prometheus/node_exporter/releases/latest | grep browser_download_url.*linux-amd64.tar.gz | cut -d : -f 2,3 | tr -d \"`
-    ${curl_cmd} \
-    ${download_url} > node_exporter.tar.gz
-  - tar zxf node_exporter.tar.gz
-  - mv node_exporter-*/node_exporter /usr/bin
-  - rm -rf node_exporter*
-  - chown node_exporter:node_exporter /usr/bin/node_exporter
-  - chcon -t bin_t /usr/bin/node_exporter
-  - systemctl daemon-reload
-  - systemctl enable node_exporter
-  - systemctl start node_exporter
-  - systemctl enable iscsid
-  - systemctl start iscsid
-{{- if .VolumeAttachments}}
-  # iSCSI Volume attachments
-  # ----------------------------------------------------
-  # This requires a host to create with a volume attached and will set up
-  # multipathd to create a dm device for it. Once the host is up, Metal can
-  # add additional volume attachments and the user will need to do
-  # "iscsiadm -m session --rescan" and a new dm device will be created.
-  {{- range $da := .ISCSIDiscoveryAddressesV3}}
-  - iscsiadm --mode discovery -t sendtargets  -p "{{$da }}"
-  {{- end}}
-  {{- if .ISCSIDiscoveryAddressesV3}}
-  - iscsiadm --mode node --login
-  {{- end}}
-{{- end}}
+  # Required: write_files
+  - if [ ! -f /var/lib/cloud/instance/scripts/glm-node-exporter.sh ] || [ ! -f /var/lib/cloud/instance/scripts/glm-iscsid.sh ]; then
+      /usr/bin/cloud-init single -n write_files; fi
+  # Script for node exporter service
+  - /var/lib/cloud/instance/scripts/glm-node-exporter.sh
+  # Script for iscsid service
+  - /var/lib/cloud/instance/scripts/glm-iscsid.sh
 
+# cloud-init module "power_state" handles shutdown/reboot
+#   after all config modules have been run.
+# ----------------------------------------------------
 power_state:
   # In some cloud-init-enabled images, a few services may race with cloud-init
   # during boot, causing issues with initial modules. To avoid such issues,

--- a/glm-test-service-image.sh
+++ b/glm-test-service-image.sh
@@ -11,15 +11,15 @@
 # Ways to use this script:
 # * glm-test-service-image.sh RHEL-9.0-BareMetal.yml
 
-set -euo pipefail
+set -eou pipefail
 
 # The clean function cleans up any lingering files
 # data that might be present when the script exits.
 clean() {
-    # remove the temp file
-    rm -f $LOCAL_IMAGE_FILENAME
+  rm -f ${LOCAL_IMAGE_FILENAME}
 }
 
+# Set a trap to call the clean function on exit
 trap clean EXIT
 
 usage() {
@@ -29,7 +29,7 @@ EOF
 }
 
 # check command line arguments
-if [[ $# -ne 1 ]]; then
+if [[ $# -lt 1 ]]; then
   echo "bad command line args"
   usage
   exit 1
@@ -42,51 +42,59 @@ fi
 #   file_size: 5360998400
 #   signature: "750db9d2434faefd1cf2ec1b0f219541b594efa1a99202775e2e6431582ab4bf"
 #   algorithm: sha256sum
-eval $(egrep "file_size:|display_url:|secure_url:|signature:|algorithm:" $* | sed -e "s/^ *//" -e "s/: */=/")
+eval "$(grep -E "file_size:|display_url:|secure_url:|signature:|algorithm:" "$*" | sed -e "s/^ *//" -e "s/: */=/")"
 
 # Check that required parameters exist.
 # Allow $display_url to be optional.
-if [ -z "$file_size" -o -z "$secure_url" -o \
-     -z "$file_size" -o -z "$algorithm" ]; then
+if [ -z ${file_size} ] || [ -z ${display_url} ] || [ -z ${secure_url} ] || [ -z ${file_size} ] || [ -z ${algorithm} ] || [ -z ${signature} ]; then
   usage
   exit 1
 fi
 
 # print the image description that we found
-echo "OS image file to be tested:"
-echo "  Secure URL:" $secure_url
-echo "  Display URL:" $display_url
-echo "  Image size:" $file_size
-echo "  Image signature:" $signature
-echo "  Signature algorithm:" $algorithm
+echo -e "\nOS image file to be tested:"
+echo "  Secure URL: ${secure_url}"
+echo "  Display URL: ${display_url}"
+echo "  Image size: ${file_size}"
+echo "  Image signature: ${signature}"
+echo "  Signature algorithm: ${algorithm}"
 
 # make sure we have the tool for $algorithm
-which $algorithm > /dev/null 2>&1
+which "$algorithm" > /dev/null 2>&1
 if [ $? -ne 0 ]
 then
-  echo "$algorithm not found. Please install."
-  exit -1
+  echo "ERROR $algorithm not found. Please install."
+  exit 1
 fi
 
 # make temp filename
 LOCAL_IMAGE_FILENAME="$(mktemp /tmp/os-image-XXXXXX.img)"
 
-# download the image
-echo
-echo wget -O $LOCAL_IMAGE_FILENAME $secure_url
-wget -O $LOCAL_IMAGE_FILENAME $secure_url
+# download the image from the source (Web Server, AWS S3, etc)
+# ======================================================================
+# Note: You may use "--no-check-certificate" for Self-signed certificate
+echo -e "\nDownload the image from the source:"
+args=(
+  --no-proxy #optional parameter
+  --no-check-certificate #optional parameter
+)
+DOWNLOAD="wget                                   \
+${args[*]} `#add parameters from the list above` \
+-O ${LOCAL_IMAGE_FILENAME} ${secure_url}"
+echo "$DOWNLOAD"
+$DOWNLOAD
 RC=$?
 if [ $RC -ne 0 ]; then
-    echo "wget failed to download image"
-    exit 1
+  echo "ERROR wget failed to download image"
+  exit 1
 fi
 
 # Verify image file exists
 stat ${LOCAL_IMAGE_FILENAME} > /dev/null 2>&1
 RC=$?
 if [ $RC -ne 0 ]; then
-    echo "Image file '${LOCAL_IMAGE_FILENAME}' not found."
-    exit 1
+  echo "ERROR Image file ${LOCAL_IMAGE_FILENAME} not found."
+  exit 1
 fi
 
 # Get file size
@@ -94,22 +102,24 @@ SIZE=$(stat -L -c "%s" "$LOCAL_IMAGE_FILENAME")
 
 # Check file size
 if [ "$SIZE" -ne "$file_size" ]; then
-   echo file size error. expected $file_size got $SIZE
-   exit 1
+  echo "ERROR file size error. expected ${file_size} got ${SIZE}"
+  exit 1
 fi
-echo "Image Size has been verified (" $SIZE "bytes )"
+echo "Test 1: Image size has been verified ( ${SIZE} bytes )"
 
 # Calculate checksum
 SUM=$($algorithm $LOCAL_IMAGE_FILENAME | sed "s/ .*//")
 
+echo
 # Check checksum
 if [ "$SUM" != "$signature" ]; then
-   echo file checksum error. expected $signature got $SUM
-   exit 1
+  echo "ERROR file checksum error. expected ${signature} got ${SUM}"
+  exit 1
 fi
-echo "Image Signature has been verified (" $SUM ")"
+echo "Test 2: Image signature has been verified ( ${SUM} )"
 
 # success
-echo The OS image size and signature have been verified
+echo "SUCCESS! The OS image size and signature have been verified"
 
+# remove the temp file
 clean


### PR DESCRIPTION
Pushing the latest changes from bmaas-byoi-rhel-build [PR #24]
--
Summary:
<1> Fixed a couple of issues related to iSCSI LUNs' visibility and cloud-init modules "write_files" and "runcmd".
<2> cloud-init module "runcmd" is further simplified with calling scripts (written part of module "write_files"). With this change, users can still access/edit these scripts as and when required after host creation.
<3> Run the test script by default after the image upload.
<4> Add an optional parameter SKIP_TEST and a function run_test to run/skip the test script glm-test-service-image.sh after the image upload.
<5> Adding Rocky 9.0 to the tested OS list.
