### PR TITLE
Adding supported network bond configuration details

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,20 @@ Linux            | Oracle Linux (OL) | 8.6, 8.9, 9.3, 9.4
 Linux            | Rocky Linux       | 8.8, 9.0
 
 ## Supported Network Bonding Configuration for HPE PCE Bare Metal
-This section provides the BMaaS OS configurations for RHEL and its derivatives (Oracle Linux and Rocky Linux), outlining Switch LAG settings along with bonding modes and key configuration parameters.
+This section provides the BMaaS OS configurations for RHEL and its derivatives (Oracle Linux and Rocky Linux), outlining Switch LAG (Link Aggregation Group) settings along with bonding modes and key configuration parameters.<BR><BR>
+**Additional Reference:** For a detailed overview of bonding modes and the required switch settings, please refer to the official [RHEL9 Networking Guide](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking#configuring-network-bonding_configuring-and-managing-networking).
 
 Switch LAG   | Configuration Details |
 ------------ | --------------------- |
-**Disabled** | <1> Configure the following in the OS Image Service Template file [glm-service.yml.template](glm-service.yml.template):  <BR> `no_switch_lag: true` <BR> <2> Configure the following in [glm-cloud-init.template](glm-cloud-init.template): <BR> `Bond-mode: balance-tlb` <BR> `bond-miimon: 100` <BR> `bond-xmit_hash_policy: 2` |
-**Enabled**  | <1> Configure the following in the cloud-init configuration file [glm-service.yml.template](glm-service.yml.template):  <BR> `no_switch_lag: false` <BR> <2> Configure the following in [glm-cloud-init.template](glm-cloud-init.template): <BR> `Bond-mode: balance-xor`  <BR> `bond-miimon: 100`  <BR> `bond-xmit_hash_policy: 2` |
+**Disabled** <BR> (Default Configuration) | **Configuration Details:** This is the **$${\color{red}default}$$** bonding  mode for the host. <BR><BR> **Behavior:** When the switch LAG is disabled, the bond mode is set to TLB (Transmit Load Balancing). In this mode, only one network port will receive incoming traffic, while all network ports in the bond will participate in transmitting outgoing traffic. |
+**Enabled** <BR> (User Configurable)  | **Configuration Details:** When the switch LAG is enabled, the bonding mode **needs to be set manually to Balance XOR**. <BR><BR> **Behavior:** When the switch LAG is enabled and the bond mode is set to XOR, the switch is configured to allow receiving traffic on both network ports. <BR><BR> **Configuration Steps:** <BR> <1> Set `no_switch_lag` to `false` in the **OS Image Service file** ([glm-service.yml.template](glm-service.yml.template)) <BR> <2> In the cloud-init configuration file ([glm-cloud-init.template](glm-cloud-init.template)), update the bonding mode by setting: <BR> `bond-mode: balance-xor`. |
 
 
 # Quick Guide for Build Process
 
 Workflow for Building Image:
 
-![image](https://github.com/user-attachments/assets/e6c66b43-2776-4b22-9795-0fe2e4ed5dfc)
+![image](https://github.com/user-attachments/assets/ced85a55-118b-42b2-8d24-2a6e0de3ed3f)
 
 
 **Prerequisites:**

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Linux            | RHEL              | 8.6, 8.7, 8.10, 9.0, 9.1, 9.2, 9.4, 9.5
 Linux            | Oracle Linux (OL) | 8.6, 8.9, 9.3, 9.4
 Linux            | Rocky Linux       | 8.8, 9.0
 
+## Supported Network Bonding Configuration for HPE PCE Bare Metal
+This section provides the BMaaS OS configurations for RHEL and its derivatives (Oracle Linux and Rocky Linux), outlining Switch LAG settings along with bonding modes and key configuration parameters.
+
+Switch LAG   | Configuration Details |
+------------ | --------------------- |
+**Disabled** | <1> Configure the following in the OS Image Service Template file [glm-service.yml.template](glm-service.yml.template):  <BR> `no_switch_lag: true` <BR> <2> Configure the following in [glm-cloud-init.template](glm-cloud-init.template): <BR> `Bond-mode: balance-tlb` <BR> `bond-miimon: 100` <BR> `bond-xmit_hash_policy: 2` |
+**Enabled**  | <1> Configure the following in the cloud-init configuration file [glm-service.yml.template](glm-service.yml.template):  <BR> `no_switch_lag: false` <BR> <2> Configure the following in [glm-cloud-init.template](glm-cloud-init.template): <BR> `Bond-mode: balance-xor`  <BR> `bond-miimon: 100`  <BR> `bond-xmit_hash_policy: 2` |
+
 
 # Quick Guide for Build Process
 


### PR DESCRIPTION
Ref: Adding supported network bond configuration details #31
==

This PR adds documentation to the README.md file regarding the configuration of Link Aggregation (LAG) settings for bonding modes. The updates include:

**Switch Lag Disabled, Bond Mode TLB:**
---------------------------------------------
**This is the default configuration**.
Describes the behavior when the switch lag is disabled, and the bond mode is set to TLB (Transmit Load Balancing). It details that only one network port will receive traffic, while all network ports will participate in transmitting traffic.
Includes configuration instructions for the OS Image Service Template and cloud-init configuration for this setup.

**Switch Lag Enabled, Balance Mode XOR:**
---------------------------------------------
**This is the User Configurable**.
Explains the behavior when switch lag is enabled and the bonding mode is set to Balance XOR. The switch allows receiving traffic on both network ports, with traffic transmission determined by the xmit policy.
Includes configuration instructions for the OS Image Service Template and cloud-init configuration for this setup.
